### PR TITLE
Add --shelve to prelaunch command

### DIFF
--- a/.pakku/prism-overrides/instance.cfg
+++ b/.pakku/prism-overrides/instance.cfg
@@ -1,6 +1,6 @@
 [General]
 name=Panpack
-PreLaunchCommand=java -jar pakku.jar fetch
+PreLaunchCommand=java -jar pakku.jar fetch --shelve
 ConfigVersion=1.2
 InstanceType=OneSix
 JoinServerOnLaunch=false


### PR DESCRIPTION
By default, fetching using Pakku simply (permanently) deletes any mods not in the manifest already. This can be confusing and VERY ANNOYING to people who are new to Pakku, especially since your files are deleted permanently. Adding --shelve sends them to `.pakku/shelf` instead